### PR TITLE
OLED_draw_bmp_by_size

### DIFF
--- a/WCH/ch32v003f4p6-evt-r0-1v1-i2c-128x64/source/ssd1306/oled_segment.c
+++ b/WCH/ch32v003f4p6-evt-r0-1v1-i2c-128x64/source/ssd1306/oled_segment.c
@@ -303,6 +303,28 @@ void OLED_draw_bmp(uint8_t x0, uint8_t y0, uint8_t x1, uint8_t y1, const uint8_t
   }
 }
 
+/*
+ * Draw a bitmap from x0 & y0 with the w & h sizes
+ * x0 => X origin coordinate
+ * y0 => Y origin coordinate
+ * w  => Width in pixels of the bitmap
+ * h  => Heiht in pixels of the bitmap
+ * bmp  => Bitmap array
+ */
+void OLED_draw_bmp_by_size(uint8_t x0, uint8_t y0, uint8_t w, uint8_t h, const uint8_t* bmp) {
+	int z=0;
+  for(uint8_t y = y0; y < y0+(h/8); y++) {
+    OLED_setpos(x0, y);
+    I2C_start(OLED_ADDR);
+    I2C_write(OLED_DAT_MODE);
+    for(uint8_t x = x0; x < x0+w; x++)
+		{
+			I2C_write(bmp[z]);
+			z++;
+		}
+    I2C_stop();
+  }
+}
 
 /*
  * Draw one pixel in the screenbuffer

--- a/WCH/ch32v003f4p6-evt-r0-1v1-i2c-128x64/source/ssd1306/oled_segment.h
+++ b/WCH/ch32v003f4p6-evt-r0-1v1-i2c-128x64/source/ssd1306/oled_segment.h
@@ -102,6 +102,7 @@ void OLED_printB(uint8_t value);  // print hex byte value
 void OLED_setpos(uint8_t x, uint8_t y);
 void OLED_fill(uint8_t p);
 void OLED_draw_bmp(uint8_t x0, uint8_t y0, uint8_t x1, uint8_t y1, const uint8_t *bmp);
+void OLED_draw_bmp_by_size(uint8_t x0, uint8_t y0, uint8_t w, uint8_t h, const uint8_t* bmp);
 void OLED_DrawPixel(uint8_t x, uint8_t y, SSD1306_COLOR color);
 void OLED_EmbeetleLogo(void);
 


### PR DESCRIPTION
Added a method to draw a bitmap from one origin coordinate with the size of the bitmap instead of a secondary coordinate to end. 
Like the "drawBitmap" method from the Adafruit_SSD1306 library on Arduino.